### PR TITLE
make python3 shebangs use env

### DIFF
--- a/dict_uk/expand/affix.py
+++ b/dict_uk/expand/affix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # -*- coding: utf-8 -*-
 

--- a/dict_uk/expand/base_tags.py
+++ b/dict_uk/expand/base_tags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/dict_uk/expand/expand.py
+++ b/dict_uk/expand/expand.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # -*- coding: utf-8 -*-
 # This script loads hunspell-like affixes and allows to perform some actions

--- a/dict_uk/expand/expand_all.py
+++ b/dict_uk/expand/expand_all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/dict_uk/expand/expand_comps.py
+++ b/dict_uk/expand/expand_comps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # -*- coding: utf-8 -*-
 

--- a/dict_uk/expand/tagged_wordlist.py
+++ b/dict_uk/expand/tagged_wordlist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # -*- coding: utf-8 -*-
 

--- a/dict_uk/expand/test/test_expand.py
+++ b/dict_uk/expand/test/test_expand.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/dict_uk/expand/util.py
+++ b/dict_uk/expand/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import sys

--- a/dict_uk/expand/verb_reverse.py
+++ b/dict_uk/expand/verb_reverse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """
 Created on Aug 29, 2015

--- a/dict_uk/tools/convert/convert.py
+++ b/dict_uk/tools/convert/convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import re


### PR DESCRIPTION
For portability on systems where python3 interpreter located elsewhere.