### PR TITLE
Fix predic #37

### DIFF
--- a/data/dict/exceptions.lst
+++ b/data/dict/exceptions.lst
@@ -106,7 +106,6 @@
 бельмес бельмес noun:m:v_naz:rare
 бельмеса бельмес noun:m:v_rod
 язицех язик noun:p:v_mis
-властен властен predic
 
 давніх-давен давніх-давен noun:p:v_rod:ns
 
@@ -550,11 +549,12 @@
 # короткі прикметники
 безвинен безвинний adj:m:v_naz/v_zna:short
 благословен благословенний adj:m:v_naz/v_zna:short
-#блажен блаженний adj:m:v_naz/v_zna:short
+блажен блаженний adj:m:v_naz/v_zna:short
 варт вартий adj:m:v_naz/v_zna:short
 винен винний adj:m:v_naz/v_zna:short
 #вістен вістний adj:m:v_naz/v_zna:short
 вістен вісний adj:m:v_naz/v_zna:short:rare
+властен власний adj:m:v_naz/v_zna:short:rare
 годен годний adj:m:v_naz/v_zna:short:coll
 дивен дивний adj:m:v_naz/v_zna:short
 достоїн достойний adj:m:v_naz/v_zna:short
@@ -582,8 +582,8 @@
 ненавистен ненависний adj:m:v_naz/v_zna:short
 певен певний adj:m:v_naz/v_zna:short
 повен повний adj:m:v_naz/v_zna:short
-#повинен повинний adj:m:v_naz/v_zna:short
-#потрібен потрібний adj:m:v_naz/v_zna:short
+повинен повинний adj:m:v_naz/v_zna:short
+потрібен потрібний adj:m:v_naz/v_zna:short
 прекрасен прекрасний adj:m:v_naz/v_zna:short
 привинен привинний adj:m:v_naz/v_zna:short
 провинен провинний adj:m:v_naz/v_zna:short


### PR DESCRIPTION
Зміни:
- "їстоньки predic" - просто зайве
- всі predic, що є насправді прикметниками в скороченій формі, але залишились predic, винесла в прикметники: блажен, повинен, потрібен і властен. Я перевірила - вони у всіх значеннях можуть бути в обох формах (повній та скороченій). "Повинен", щоправда, має трохи інший відтінок, але це той же прикметник.

Коментарі від Василя за 25.01.15 щодо саме цих слів:
"Мені це подобається. Такі форми мають синтаксичну роль присудкового слова, а насправді це прикметники в короткій формі. І взагалі: наші теги мають відповідати радше класам словозміни (які близькі до частин мови), ніж синтаксичним ролям."
та
"Тег predic варто присвоювати лише тим словам, що не вживаються в іншій функції. Тому, наприклад, "телень", "телень-телень" - це звуконаслідувальні слова, а "нітелень", "анітелень" - присудкові."

За 26.02.15 (через місяць) є ще від Василя коментар, що "блажен/потрібен/повинен predic - ці слова лише predic, здається", але він певно десь з контексту випав на той момент)

Cast @arysin :)